### PR TITLE
restore resizing instead of fixing width and height of window

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -113,7 +113,8 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
 {
     /* Open CSS when configured */
     this->setStyleSheet(GUIUtil::loadStyleSheet());
-    this->setFixedSize(1080,730);
+    
+    GUIUtil::restoreWindowGeometry("nWindow", QSize(850, 550), this);
 
     QString windowTitle = tr("Atheneum") + " - ";
 #ifdef ENABLE_WALLET


### PR DESCRIPTION
Window size has been changed to a fixed width and height, which does not fit many screens.

This change should restore the resizing capabilities.